### PR TITLE
Update list modal content from 'collection' to 'list'

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -117,12 +117,12 @@ const List = ({ id, list, booksInList, refetchLists }) => {
           {!deleteList.isLoading && (
             <>
               <h2 className="text-2xl">
-                Are you sure you want to delete collection {list.name}?
+                Are you sure you want to delete list {list.name}?
               </h2>
               <div>
                 <p className="text-xl my-4">
-                  Deleting this collection will also remove the following books
-                  from your collection:
+                  Deleting this list will also remove the following books
+                  from your list:
                 </p>
                 <ul className="flex flex-col">
                   {booksInList.map((book) => (
@@ -136,7 +136,7 @@ const List = ({ id, list, booksInList, refetchLists }) => {
                 onKeyPress={(e) => e.key === 'Enter' && deleteListHandler}
                 type="button"
               >
-                Delete Collection
+                Delete List
               </button>
             </>
           )}


### PR DESCRIPTION
Updated modal content, from 'collection' to 'list' to follow new naming convention. 
![image](https://user-images.githubusercontent.com/65582950/197664020-eba7eee4-7114-416d-907f-8639f6d0bbbe.png)
